### PR TITLE
Align AGP configuration with central capabilities

### DIFF
--- a/ARKA_AGENT/client/acme/ARKAA19-AGENT-CAPABILITIES.yaml
+++ b/ARKA_AGENT/client/acme/ARKAA19-AGENT-CAPABILITIES.yaml
@@ -13,11 +13,11 @@ exports:
   
   agents:
     # === AGP ===
-    agp-architecte-gouvernance-produit:
+    agp: &agp_permissions
       use_profile: agp-architecte-gouvernance-produit
       permissions:
         - "feature:*"        # Tout sur features
-        - "epic:*"           # Tout sur epics  
+        - "epic:*"           # Tout sur epics
         - "us:*"             # Tout sur US
         - "order:*"          # Ordres de gouvernance
         - "decision:*"       # Décisions AGP
@@ -25,6 +25,9 @@ exports:
         - "*:v"              # Validate sur tout
         - "-delete"          # Jamais delete
       default_map: FEATURE_CREATE
+
+    agp-architecte-gouvernance-produit:
+      <<: *agp_permissions
       
     # === PMO ===
     arka-product-manager-officer:

--- a/ARKA_AGENT/client/acme/experts/ARKA_AGENT15-agp.yaml
+++ b/ARKA_AGENT/client/acme/experts/ARKA_AGENT15-agp.yaml
@@ -14,7 +14,8 @@ core_identity:
   scope: "Gouvernance, ADR, labels, validation, escalade"
   
 capabilities:
-  do: 
+  do:
+    - "Créer et notifier"
     - "Émettre ADR"
     - "Appliquer labels/gates"
     - "Refuser/valider livrables"
@@ -33,16 +34,7 @@ workflow:
     - "ADR publication"
     
 # === PERMISSIONS (format ARKPR09) ===
-permissions_ref: "ARKAA19-AGENT-CAPABILITIES:agents.agp-architecte-gouvernance-produit"
-# Ou directement :
-permissions:
-  - "feature:*"
-  - "epic:*"
-  - "us:*"
-  - "order:*"
-  - "decision:*"
-  - "*:rv"        # Read + Validate sur tout
-  - "-delete"     # Jamais delete
+permissions_ref: "ARKAA19-AGENT-CAPABILITIES:agents.agp"
 
 # === RÉFÉRENCES SPÉCIFIQUES AGP ===
 governance_tools:

--- a/ARKA_AGENT/client/acme/wakeup/ARKAA08-WAKEUP-AGP.yaml
+++ b/ARKA_AGENT/client/acme/wakeup/ARKAA08-WAKEUP-AGP.yaml
@@ -10,7 +10,10 @@ rules_index_ref:     ARKPR20-WAKEUP-POLICIES:exports.rules_index_ref
 guardrails_ref:      ARKPR20-WAKEUP-POLICIES:exports.guardrails
 
 available_intents:
-  - AGP_GATE
+  - GATE_NOTIFY
+  - ORDER_CREATE
+  - DECISION_PUBLISH
+  - DOCUMENT_CREATE
 include_common_intents_ref: ARKPR20-WAKEUP-POLICIES:exports.intents_common
 
 memory:


### PR DESCRIPTION
## Summary
- remove the duplicated AGP permissions and reference the central capabilities map
- clarify the AGP persona responsibilities so the expert can create and notify governance artifacts
- expose valid wake-up intents and add an `agents.agp` export for centralised permissions resolution

## Testing
- bash bin/os-run.sh agp DOCUMENT_CREATE '{"documentId":"ADR-001","title":"Choix Architecture","type":"ADR"}' *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68da3b449cd48331bef3b75cf486021e